### PR TITLE
[5] - api-gateway - added gateway discovery locator: Closes #5

### DIFF
--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -3,19 +3,33 @@ eureka:
     client:
       serverUrl:
         defaultZone: http://localhost:8761/eureka/
+logging:
+  level:
+    org:
+      springframework:
+        cloud:
+          gateway:
+            handler:
+              RoutePredicateHandlerMapping: DEBUG
 spring:
-  cloud:
-    gateway:
-      routes[0]:
-        id: EMPLOYEE-SERVICE
-        uri: lb://EMPLOYEE-SERVICE
-        predicates[0]: Path=/api/employees/**
-      routes[1]:
-        id: DEPARTMENT-SERVICE
-        uri: lb://DEPARTMENT-SERVICE
-        predicates[0]: Path=/api/departments/**
   application:
     name: API-GATEWAY
+  cloud:
+    gateway:
+      discovery:
+        locator:
+          # allows to automatically locate needed service.
+          # NOTE: service name should be in request url --> http://localhost:9191/employee-service/api/employee/....
+          enabled: true
+          lower-case-service-id: true
+  #      routes[0]:
+  #        id: EMPLOYEE-SERVICE
+  #        uri: lb://EMPLOYEE-SERVICE
+  #        predicates[0]: Path=/api/employees/**
+  #      routes[1]:
+  #        id: DEPARTMENT-SERVICE
+  #        uri: lb://DEPARTMENT-SERVICE
+  #        predicates[0]: Path=/api/departments/**
 
 server:
   port: 9191


### PR DESCRIPTION
added gateway discovery locator.

This feature uses service name in the url, therefore I will go with manual creation.

PR will be on hold.