### PR TITLE
7 create centralized place for properties

### DIFF
--- a/api-gateway/pom.xml
+++ b/api-gateway/pom.xml
@@ -32,6 +32,11 @@
 		</dependency>
 
 		<dependency>
+			<groupId>org.springframework.cloud</groupId>
+			<artifactId>spring-cloud-starter-config</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>

--- a/api-gateway/src/main/resources/application.yml
+++ b/api-gateway/src/main/resources/application.yml
@@ -1,26 +1,5 @@
-eureka:
-  instance:
-    client:
-      serverUrl:
-        defaultZone: http://localhost:8761/eureka/
 spring:
-  cloud:
-    gateway:
-      routes[0]:
-        id: EMPLOYEE-SERVICE
-        uri: lb://EMPLOYEE-SERVICE
-        predicates[0]: Path=/api/employees/**
-      routes[1]:
-        id: DEPARTMENT-SERVICE
-        uri: lb://DEPARTMENT-SERVICE
-        predicates[0]: Path=/api/departments/**
   application:
     name: API-GATEWAY
-
-server:
-  port: 9191
-management:
-  endpoints:
-    web:
-      exposure:
-        include: '*'
+  config:
+    import: optional:configserver:http://localhost:8888

--- a/config-server/src/main/resources/application.yml
+++ b/config-server/src/main/resources/application.yml
@@ -1,6 +1,15 @@
 spring:
   application:
     name: CONFIG-SERVER
+  cloud:
+    config:
+      server:
+        git:
+          uri: https://github.com/OleksandrBodnarchuk/configuration-server-demo
+          # clone at the startup
+          clone-on-start: true
+          # keep all the files on master branch
+          default-label: main
 
 server:
   port: 8888

--- a/department-service/pom.xml
+++ b/department-service/pom.xml
@@ -47,6 +47,14 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/department-service/src/main/java/pl/alex/departmentservice/controller/MessageController.java
+++ b/department-service/src/main/java/pl/alex/departmentservice/controller/MessageController.java
@@ -1,0 +1,19 @@
+package pl.alex.departmentservice.controller;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RefreshScope
+@RestController
+public class MessageController {
+
+  @Value("${my.test.message}")
+  private String message;
+
+  @GetMapping("message")
+  public String getMessageFromExternalConfig(){
+    return message;
+  }
+}

--- a/department-service/src/main/resources/application.yml
+++ b/department-service/src/main/resources/application.yml
@@ -1,21 +1,5 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/department_db
-    username: root
-    password: alex
-  jpa:
-    properties:
-      hibernate:
-    hibernate:
-      ddl-auto: update
   application:
     name: DEPARTMENT-SERVICE
-
-server:
-  port: 8090
-
-eureka:
-  instance:
-    client:
-      serverUrl:
-        defaultZone: http://localhost:8761/eureka/
+  config:
+    import: optional:configserver:http://localhost:8888

--- a/department-service/src/main/resources/application.yml
+++ b/department-service/src/main/resources/application.yml
@@ -3,3 +3,8 @@ spring:
     name: DEPARTMENT-SERVICE
   config:
     import: optional:configserver:http://localhost:8888
+management:
+  endpoints:
+    web:
+      exposure:
+        include: '*'

--- a/employee-service/pom.xml
+++ b/employee-service/pom.xml
@@ -60,6 +60,14 @@
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-starter-config</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>

--- a/employee-service/src/main/resources/application.yml
+++ b/employee-service/src/main/resources/application.yml
@@ -1,24 +1,5 @@
 spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/employee_db
-    username: root
-    password: alex
-  jpa:
-    properties:
-      hibernate:
-    hibernate:
-      ddl-auto: update
   application:
     name: EMPLOYEE-SERVICE
-server:
-  port: 8080
-
-department:
-  service:
-    url: http://localhost:8090/api/departments
-
-eureka:
-  instance:
-    client:
-      serverUrl:
-        defaultZone: http://localhost:8761/eureka/
+  config:
+    import: optional:configserver:http://localhost:8888


### PR DESCRIPTION
1. Created repository to store properties externally --> https://github.com/OleksandrBodnarchuk/configuration-server-demo
2. Added config-service app and enabled it as a configuration server
3. Added spring.config.import to all microservices with git repo address to get configuration.properties
4. Added pom.xml dependencies to all microservices to get properties from external server -> spring-cloud-starter-config
